### PR TITLE
fix bug lessthan

### DIFF
--- a/src/language-wxml/index.ts
+++ b/src/language-wxml/index.ts
@@ -13,5 +13,8 @@ export default async function (sourceCode : string, options : any = { }) {
   })
   const distCode : string = generator(distAst)
 
-  return distCode
+  // Undo the hacky fix from parser
+  return distCode.replace(/<>/g, (m) => {
+    return `<`
+  })
 }

--- a/src/language-wxml/parser.ts
+++ b/src/language-wxml/parser.ts
@@ -15,6 +15,12 @@ export default function parse (sourceCode : string) {
       lowerCaseTags: false,
       recognizeSelfClosing: true
     })
+
+    // When change < to <>, htmlparser2 reads as part of same text node.
+    const hackyFix = sourceCode.replace(/(>[^<]*)<(.*<)/g, (m, $1, $2) => {
+    return `${$1}<>${$2}`
+    })
+
     parser.write(sourceCode)
     parser.end()
   })

--- a/src/language-wxml/parser.ts
+++ b/src/language-wxml/parser.ts
@@ -21,7 +21,7 @@ export default function parse (sourceCode : string) {
     return `${$1}<>${$2}`
     })
 
-    parser.write(sourceCode)
+    parser.write(hackyFix)
     parser.end()
   })
 }


### PR DESCRIPTION
add hacky-fix for htmlparser2

Fix:   convert `<` to `<>` to stay in same text-node when parsed by htmlparser2.
then in index.ts, do another replace to convert `<>` to `<`.

